### PR TITLE
AWS Neptune Terraform triggers CKV_AWS_44

### DIFF
--- a/terraform/aws/consts.tf
+++ b/terraform/aws/consts.tf
@@ -52,3 +52,9 @@ variable "password" {
   description = "Database password"
   default     = "Aa1234321Bb"
 }
+
+variable "neptune-dbname" {
+  type        = "string"
+  description = "Name of the Neptune graph database"
+  default     = "neptunedb1"
+}

--- a/terraform/aws/neptune.tf
+++ b/terraform/aws/neptune.tf
@@ -1,0 +1,25 @@
+resource "aws_neptune_cluster" "default" {
+  cluster_identifier                  = var.neptune-dbname
+  engine                              = "neptune"
+  backup_retention_period             = 5
+  preferred_backup_window             = "07:00-09:00"
+  skip_final_snapshot                 = true
+  iam_database_authentication_enabled = false
+  apply_immediately                   = true
+  storage_encrypted                   = false
+}
+
+resource "aws_neptune_cluster_instance" "default" {
+  count                               = 1
+  cluster_identifier                  = aws_neptune_cluster.default.id
+  engine                              = "neptune"
+  instance_class                      = "db.t3.medium" # Smallest instance type listed for neptune https://aws.amazon.com/neptune/pricing/
+  apply_immediately                   = true
+  #publicly_accessible                = true # No longer supported, API returns create error. See https://docs.aws.amazon.com/neptune/latest/userguide/api-instances.html#CreateDBInstance
+}
+
+resource "aws_neptune_cluster_snapshot" "default" {
+  db_cluster_identifier               = aws_neptune_cluster.default.id
+  db_cluster_snapshot_identifier      = "resourcetestsnapshot1"
+}
+


### PR DESCRIPTION
Adds simple 1x medium node Neptune cluster instance, one snapshot, encryption disabled.

Triggers CKV_AWS_44
<img width="932" alt="Screenshot 2020-08-24 at 16 56 13" src="https://user-images.githubusercontent.com/4842186/91067554-fa440c80-e62a-11ea-8c63-38e8c655c814.png">


Deploys/Destroys successfully with the following:

```
terraform apply -target=aws_neptune_cluster.default -target=aws_neptune_cluster_instance.default -target=aws_neptune_cluster_snapshot.default

terraform destroy -target=aws_neptune_cluster.default -target=aws_neptune_cluster_instance.default -target=aws_neptune_cluster_snapshot.default
```
