### PR TITLE
Updating image to a currently available Debian release in GCP

### DIFF
--- a/terraform/gcp/instances.tf
+++ b/terraform/gcp/instances.tf
@@ -6,7 +6,7 @@ resource "google_compute_instance" "server" {
   zone         = data.google_compute_zones.zones.names[0]
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-9"
+      image = "debian-cloud/debian-10"
     }
     auto_delete = true
   }
@@ -35,6 +35,7 @@ resource "google_compute_instance" "server" {
 
 resource "google_compute_disk" "unencrypted_disk" {
   name = "terragoat-${var.environment}-disk"
+  zone = data.google_compute_zones.zones.names[0]
   labels = {
     git_commit           = "2bdc0871a5f4505be58244029cc6485d45d7bb8e"
     git_file             = "terraform__gcp__instances_tf"


### PR DESCRIPTION
I received a few errors when running this against GCP recently and wanted to push back the changes I needed to make in order to get the Terraform to be deployable.  Thanks for all the work on this project!

- Updated image to the lowest currently available Debian release in GCP.
- Added a zone property to the google_compute_disk resource.