### PR TITLE
change deprecated resources

### DIFF
--- a/terraform/aws/consts.tf
+++ b/terraform/aws/consts.tf
@@ -25,25 +25,25 @@ variable "region" {
   default = "us-west-2"
 }
 
-variable ami {
-  type    = "string"
+variable "ami" {
+  type    = string
   default = "ami-09a5b0b7edf08843d"
 }
 
 variable "dbname" {
-  type        = "string"
+  type        = string
   description = "Name of the Database"
   default     = "db1"
 }
 
 variable "password" {
-  type        = "string"
+  type        = string
   description = "Database password"
   default     = "Aa1234321Bb"
 }
 
 variable "neptune-dbname" {
-  type        = "string"
+  type        = string
   description = "Name of the Neptune graph database"
   default     = "neptunedb1"
 }

--- a/terraform/aws/db-app.tf
+++ b/terraform/aws/db-app.tf
@@ -1,6 +1,6 @@
 resource "aws_db_instance" "default" {
 
-  name                   = var.dbname
+  db_name                = var.dbname
   engine                 = "mysql"
   option_group_name      = aws_db_option_group.default.name
   parameter_group_name   = aws_db_parameter_group.default.name
@@ -263,7 +263,7 @@ cat << EnD > /tmp/dbinfo.inc
 define('DB_SERVER', '${aws_db_instance.default.endpoint}');
 define('DB_USERNAME', '${aws_db_instance.default.username}');
 define('DB_PASSWORD', '${var.password}');
-define('DB_DATABASE', '${aws_db_instance.default.name}');
+define('DB_DATABASE', '${aws_db_instance.default.db_name}');
 ?>
 EnD
 sudo mv /tmp/dbinfo.inc /var/www/inc 

--- a/terraform/aws/lambda.tf
+++ b/terraform/aws/lambda.tf
@@ -38,7 +38,7 @@ resource "aws_lambda_function" "analysis_lambda" {
 
   source_code_hash = "${filebase64sha256("resources/lambda_function_payload.zip")}"
 
-  runtime = "nodejs12.x"
+  runtime = "nodejs18.x"
 
   environment {
     variables = {

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -1,5 +1,7 @@
 resource "aws_rds_cluster" "app1-rds-cluster" {
   cluster_identifier      = "app1-rds-cluster"
+  engine                  = "aurora-mysql"
+  engine_version          = "8.0.mysql_aurora.3.05.2"
   allocated_storage       = 10
   backup_retention_period = 0
   tags = {
@@ -16,6 +18,8 @@ resource "aws_rds_cluster" "app1-rds-cluster" {
 
 resource "aws_rds_cluster" "app2-rds-cluster" {
   cluster_identifier      = "app2-rds-cluster"
+  engine                  = "aurora-mysql"
+  engine_version          = "8.0.mysql_aurora.3.05.2"
   allocated_storage       = 10
   backup_retention_period = 1
   tags = {
@@ -32,6 +36,8 @@ resource "aws_rds_cluster" "app2-rds-cluster" {
 
 resource "aws_rds_cluster" "app3-rds-cluster" {
   cluster_identifier      = "app3-rds-cluster"
+  engine                  = "aurora-mysql"
+  engine_version          = "8.0.mysql_aurora.3.05.2"
   allocated_storage       = 10
   backup_retention_period = 15
   tags = {
@@ -48,6 +54,8 @@ resource "aws_rds_cluster" "app3-rds-cluster" {
 
 resource "aws_rds_cluster" "app4-rds-cluster" {
   cluster_identifier      = "app4-rds-cluster"
+  engine                  = "aurora-mysql"
+  engine_version          = "8.0.mysql_aurora.3.05.2"
   allocated_storage       = 10
   backup_retention_period = 15
   tags = {
@@ -64,6 +72,8 @@ resource "aws_rds_cluster" "app4-rds-cluster" {
 
 resource "aws_rds_cluster" "app5-rds-cluster" {
   cluster_identifier      = "app5-rds-cluster"
+  engine                  = "aurora-mysql"
+  engine_version          = "8.0.mysql_aurora.3.05.2"
   allocated_storage       = 10
   backup_retention_period = 15
   tags = {
@@ -80,6 +90,8 @@ resource "aws_rds_cluster" "app5-rds-cluster" {
 
 resource "aws_rds_cluster" "app6-rds-cluster" {
   cluster_identifier      = "app6-rds-cluster"
+  engine                  = "aurora-mysql"
+  engine_version          = "8.0.mysql_aurora.3.05.2"
   allocated_storage       = 10
   backup_retention_period = 15
   tags = {
@@ -96,6 +108,8 @@ resource "aws_rds_cluster" "app6-rds-cluster" {
 
 resource "aws_rds_cluster" "app7-rds-cluster" {
   cluster_identifier      = "app7-rds-cluster"
+  engine                  = "aurora-mysql"
+  engine_version          = "8.0.mysql_aurora.3.05.2"
   allocated_storage       = 10
   backup_retention_period = 25
   tags = {
@@ -112,6 +126,8 @@ resource "aws_rds_cluster" "app7-rds-cluster" {
 
 resource "aws_rds_cluster" "app8-rds-cluster" {
   cluster_identifier      = "app8-rds-cluster"
+  engine                  = "aurora-mysql"
+  engine_version          = "8.0.mysql_aurora.3.05.2"
   allocated_storage       = 10
   backup_retention_period = 25
   tags = {
@@ -129,6 +145,8 @@ resource "aws_rds_cluster" "app8-rds-cluster" {
 
 resource "aws_rds_cluster" "app9-rds-cluster" {
   cluster_identifier      = "app9-rds-cluster"
+  engine                  = "aurora-mysql"
+  engine_version          = "8.0.mysql_aurora.3.05.2"
   allocated_storage       = 10
   backup_retention_period = 25
   tags = {

--- a/terraform/aws/s3.tf
+++ b/terraform/aws/s3.tf
@@ -20,7 +20,7 @@ resource "aws_s3_bucket" "data" {
   })
 }
 
-resource "aws_s3_bucket_object" "data_object" {
+resource "aws_s3_object" "data_object" {
   bucket = aws_s3_bucket.data.id
   key    = "customer-master.xlsx"
   source = "resources/customer-master.xlsx"


### PR DESCRIPTION
The code includes the deprecated resource. For example, in the const.tf file, I changed the value `"string"` to `string`. 
Source: https://developer.hashicorp.com/terraform/language/values/variables
<img width="662" alt="tg-1" src="https://github.com/user-attachments/assets/3e74f156-9659-4539-ae92-adac0a9065a7">

In the s3.tf file, I change it resource to set a file to the bucket from `aws_s3_bucket_object` to `aws_s3_object`
Source: https://library.tf/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object#resource-aws_s3_bucket_object
<img width="458" alt="tg-2" src="https://github.com/user-attachments/assets/f26b3fda-b70a-416c-9e9c-ebeb5142b8a7">

In lambda.tf, I changed the lambda runtime configuration from `nodejs12.x` to `nodejs18.x`. NodeJs 12.x in lambda function has been deprecated.
Source: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
<img width="700" alt="tg-3" src="https://github.com/user-attachments/assets/7a846caa-6000-43a4-84f8-21ccdd7822b8">

Next, in the rds.tf file, I added the `engine` configuration to each rds_cluster created because the latest version of Terraform requires an `engine` declaration in the rds_cluster.
Source: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster
<img width="434" alt="tg-4" src="https://github.com/user-attachments/assets/e855db62-7221-47a7-8819-6fb136aa98a7">

In the db-app.tf file, I changed `name` to `db_name` in the rds resource configuration.
Source: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance
<img width="420" alt="tg-5" src="https://github.com/user-attachments/assets/b4421098-bcb8-496b-8c8f-4bb6833a1609">

Related issue: #497