### PR TITLE
Terraform/Azure/networking.tf adding an NSG rule resource tied to a n…

### DIFF
--- a/terraform/azure/networking.tf
+++ b/terraform/azure/networking.tf
@@ -113,7 +113,21 @@ resource "azurerm_network_security_group" "bad_sg2" {
 }
 
 resource "azurerm_network_security_rule" "bad_rule1" {
-  name                        = "AllowRDP"
+  name                        = "AllowSSH"
+  access                      = "Allow"
+  direction                   = "Inbound"
+  priority                    = 200
+  protocol                    = "Tcp"
+  source_address_prefix       = "*"
+  source_port_range           = "*"
+  destination_port_range      = "22-22"
+  destination_address_prefix  = "*"
+  resource_group_name         = azurerm_resource_group.example.name
+  network_security_group_name = azurerm_network_security_group.bad_sg2.name
+}
+
+resource "azurerm_network_security_rule" "bad_rule2" {
+  name                        = "AllowSSH"
   access                      = "Allow"
   direction                   = "Inbound"
   priority                    = 300

--- a/terraform/azure/networking.tf
+++ b/terraform/azure/networking.tf
@@ -66,9 +66,9 @@ resource "azurerm_network_interface" "ni_win" {
   }
 }
 
-resource azurerm_network_security_group "bad_sg" {
+resource "azurerm_network_security_group" "bad_sg1" {
   location            = var.location
-  name                = "terragoat-${var.environment}"
+  name                = "terragoat-${var.environment}-bad_sg1"
   resource_group_name = azurerm_resource_group.example.name
 
   security_rule {
@@ -76,7 +76,7 @@ resource azurerm_network_security_group "bad_sg" {
     direction                  = "Inbound"
     name                       = "AllowSSH"
     priority                   = 200
-    protocol                   = "TCP"
+    protocol                   = "Tcp"
     source_address_prefix      = "*"
     source_port_range          = "*"
     destination_port_range     = "22-22"
@@ -88,7 +88,7 @@ resource azurerm_network_security_group "bad_sg" {
     direction                  = "Inbound"
     name                       = "AllowRDP"
     priority                   = 300
-    protocol                   = "TCP"
+    protocol                   = "Tcp"
     source_address_prefix      = "*"
     source_port_range          = "*"
     destination_port_range     = "3389-3389"
@@ -106,7 +106,27 @@ resource azurerm_network_security_group "bad_sg" {
   }
 }
 
-resource azurerm_network_watcher "network_watcher" {
+resource "azurerm_network_security_group" "bad_sg2" {
+  location            = var.location
+  name                = "terragoat-${var.environment}-bad-sg2"
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_network_security_rule" "bad_rule1" {
+  name                        = "AllowRDP"
+  access                      = "Allow"
+  direction                   = "Inbound"
+  priority                    = 300
+  protocol                    = "Tcp"
+  source_address_prefix       = "*"
+  source_port_range           = "*"
+  destination_port_range      = "3389-3389"
+  destination_address_prefix  = "*"
+  resource_group_name         = azurerm_resource_group.example.name
+  network_security_group_name = azurerm_network_security_group.bad_sg2.name
+}
+
+resource "azurerm_network_watcher" "network_watcher" {
   location            = var.location
   name                = "terragoat-network-watcher-${var.environment}"
   resource_group_name = azurerm_resource_group.example.name
@@ -122,9 +142,10 @@ resource azurerm_network_watcher "network_watcher" {
   }
 }
 
-resource azurerm_network_watcher_flow_log "flow_log" {
+resource "azurerm_network_watcher_flow_log" "flow_log" {
+  name                      = "terragoat-network-watcher-flow-log-${var.environment}"
   enabled                   = false
-  network_security_group_id = azurerm_network_security_group.bad_sg.id
+  network_security_group_id = azurerm_network_security_group.bad_sg1.id
   network_watcher_name      = azurerm_network_watcher.network_watcher.name
   resource_group_name       = azurerm_resource_group.example.name
   storage_account_id        = azurerm_storage_account.example.id

--- a/terraform/azure/storage.tf
+++ b/terraform/azure/storage.tf
@@ -60,8 +60,7 @@ resource "azurerm_storage_account" "example" {
 }
 
 resource "azurerm_storage_account_network_rules" "test" {
-  resource_group_name  = azurerm_resource_group.example.name
-  storage_account_name = azurerm_storage_account.example.name
+  storage_account_id = azurerm_storage_account.example.id
 
   default_action = "Deny"
   ip_rules       = ["127.0.0.1"]


### PR DESCRIPTION
# Terraform/Azure/networking.tf adding NSG rule resources tied to a new NSG called 'bad_sg2'

Currently the Azure networking resource only include a standalone NSG resource `azurerm_network_security_group ` (renamed `bad_sg1.tf`) with NSG rules defined in-line. (https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule)

This pull request proposed to add another case with a new NSG resource (`bad_sg2.tf`) tied to a couple of separate NSG rule resource `azurerm_network_security_rule ` called `bad_rule1.tf` for SSH and `bad_rule2.tf` for RDP.
(https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule)


Also included a minor correction to the `storage.tf` file which actually require the `storage_account_id`. 